### PR TITLE
hotfix [casting]: Casting error messages would display improperly

### DIFF
--- a/src/interpreter/core/eval/eval.es6
+++ b/src/interpreter/core/eval/eval.es6
@@ -29,7 +29,9 @@ import CheddarOperatorToken from '../../../tokenizer/literals/op';
 import CheddarArrayToken from '../../../tokenizer/parsers/array';
 import CheddarVariableToken from '../../../tokenizer/literals/var';
 
+
 import CheddarVariable from '../env/var';
+import CheddarClass from '../env/class';
 import NIL from '../consts/nil';
 
 // Call stack wrapper
@@ -102,8 +104,20 @@ export default class CheddarEval extends CheddarCallStack {
             if (OPERATOR === CheddarError.NO_OP_BEHAVIOR) {
                 return CheddarErrorDesc.get(OPERATOR)
                 .replace(/\$0/g, Operation.Tokens[0])
-                .replace(/\$1/g, TOKEN ? TOKEN.constructor.Name : "nil")
-                .replace(/\$2/g, DATA ? DATA.constructor.Name : "nil");
+                .replace(/\$1/g, TOKEN ? (
+                    TOKEN.constructor.Name || (
+                        TOKEN.prototype instanceof CheddarClass
+                        ? "Class"
+                        : "nil"
+                    )
+                ) : "nil")
+                .replace(/\$2/g, DATA ? (
+                    DATA.constructor.Name || (
+                        DATA.prototype instanceof CheddarClass
+                        ? "Class"
+                        : "nil"
+                    )
+                ) : "nil");
             } else {
                 this.put(OPERATOR);
             }

--- a/src/interpreter/core/primitives/cast/string.es6
+++ b/src/interpreter/core/primitives/cast/string.es6
@@ -11,7 +11,7 @@ import CheddarNumberToken from '../../../../tokenizer/literals/number';
 import HelperInit from '../../../../helpers/init';
 
 export default new Map([
-    [CheddarNumber, (LHS) => {
+    ['Number', (LHS) => {
         let Attempt = new CheddarNumberToken(LHS, 0).exec();
         if (Attempt instanceof CheddarLexer)
             return HelperInit(CheddarNumber, ...Attempt._Tokens);


### PR DESCRIPTION
Casting error messages would show as `nil` and `<target>` this
could be potentially confusing as `nil` means a variable is unset,
while the variable wouldn't. The `Name` property is too high-level
to be abstracted