### PR TITLE
Added implicit strict typing with `:=`

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,4 +2,7 @@ coverage:
   status:
     project:
       default:
-        threshold: 4% 
+        threshold: 4%
+    patch:
+      default:
+        target: 1%

--- a/src/interpreter/states/assign.es6
+++ b/src/interpreter/states/assign.es6
@@ -33,9 +33,14 @@ export default class CheddarAssign {
         let res;
 
         if (this.toks.tok(2)) {
-            let val = new CheddarEval({ _Tokens: [this.toks.tok(2)] }, this.scope);
+
+            let val = new CheddarEval({ _Tokens: [this.toks.tok(3)] }, this.scope);
             if (!((val = val.exec()) instanceof CheddarClass || val.prototype instanceof CheddarClass))
                 return val;
+
+            if (this.toks.tok(2) === ':=') {
+                stricttype = val.constructor;
+            }
 
             if (stricttype && !(val instanceof stricttype)) {
                 return `Attempted to set \`${varname}\` to a \`${

--- a/src/tokenizer/consts/err.es6
+++ b/src/tokenizer/consts/err.es6
@@ -10,3 +10,4 @@ export const EXIT_NOTFOUND = Symbol('er_EXIT_NOTFOUND');
 export const UNEXPECTED_TOKEN = Symbol('er_UNEXPECTED_TOKEN');
 export const UNMATCHED_DELIMITER = Symbol('er_UNMATCHED_DELIMITER');
 export const EXPECTED_BLOCK = Symbol('er_EXPECTED_BLOCK');
+export const ALLOW_ERROR = Symbol('er_ALLOW_ERROR');

--- a/src/tokenizer/states/assign.es6
+++ b/src/tokenizer/states/assign.es6
@@ -12,8 +12,10 @@ export default class StatementAssign extends CheddarLexer {
         let DEFS = ['var', 'let', 'const'];
         return this.grammar(true,
             [
-                DEFS, this.jumpWhite, CheddarTypedVariableToken, CheddarError.UNEXPECTED_TOKEN,
-                [['=', CheddarExpressionToken]]
+                DEFS, this.jumpWhite, CheddarTypedVariableToken, [':=', '='], CheddarError.ALLOW_ERROR, CheddarExpressionToken
+            ],
+            [
+                DEFS, this.jumpWhite, CheddarTypedVariableToken
             ]
         );
     }

--- a/src/tokenizer/tok/lex.es6
+++ b/src/tokenizer/tok/lex.es6
@@ -177,8 +177,13 @@ export default class CheddarLexer {
                         !(result instanceof CheddarLexer) &&
                         typeof defs[i][j + 1] === 'symbol'
                     )  {
-                        this.Index = Math.max(parser.Index, index);
-                        return this.error(defs[i][j + 1]);
+                        if (defs[i][j + 1] === CheddarError.ALLOW_ERROR) {
+                            j++;
+                            continue main;
+                        } else {
+                            this.Index = Math.max(parser.Index, index);
+                            return this.error(defs[i][j + 1]);
+                        }
                     }
 
                     if (result === CheddarError.EXIT_NOTFOUND) {
@@ -292,7 +297,12 @@ export default class CheddarLexer {
                             }
                         } else {
                             // this.Index = result.Index;
-                            return this.error(CheddarError.EXIT_NOTFOUND);
+                            if (defs[i][j + 1] === CheddarError.ALLOW_ERROR) {
+                                j++;
+                                continue main;
+                            } else {
+                                return this.error(CheddarError.EXIT_NOTFOUND);
+                            }
                         }
                     }
                 } else {

--- a/test/tests/expr/assignment.js
+++ b/test/tests/expr/assignment.js
@@ -28,6 +28,11 @@ describe('Assignment', function() {
             'var a: Number = 1; print a',
             '1'
         ))
+
+        it('should work with implicit definition', TestCheddarFrom.Code(
+            `let a := 1; a = 2`,
+            ''
+        ))
     })
 
     describe('reassignment', function() {


### PR DESCRIPTION
Using `:=` instead of `=` in an assignment. The variable will be implicitly, strictly declared