### PR TITLE
User-defined Operators

### DIFF
--- a/src/interpreter/links.es6
+++ b/src/interpreter/links.es6
@@ -5,10 +5,12 @@ import StatementBreak      from './states/break';
 import StatementFunc       from './states/func';
 import StatementFor        from './states/for';
 import StatementIf         from './states/if';
+import StatementOp         from './states/op';
 
 export default {
     StatementAssign,
     StatementIf,
+    StatementOp,
     StatementFor,
     StatementFunc,
     StatementBreak,

--- a/src/interpreter/states/op.es6
+++ b/src/interpreter/states/op.es6
@@ -1,0 +1,4 @@
+export default class CheddarOp {
+    constructor() { }
+    exec() { }
+}

--- a/src/tokenizer/consts/ops.es6
+++ b/src/tokenizer/consts/ops.es6
@@ -4,6 +4,9 @@
  * UOP - Unary operators
 **/
 
+export const UD_OP = new Set();
+export const UD_UOP = new Set();
+
 export const RESERVED_KEYWORDS = new Set([
     'sqrt', 'cbrt', 'root',
     'sin', 'cos', 'tan',

--- a/src/tokenizer/states/op.es6
+++ b/src/tokenizer/states/op.es6
@@ -1,0 +1,32 @@
+import CheddarLexer from '../tok/lex';
+import CheddarVariableToken from '../literals/var';
+
+import { OP, UOP } from '../consts/ops';
+
+export default class StatementOp extends CheddarLexer {
+    exec() {
+        this.open(false);
+
+        let res = this.grammar(true,
+            [
+                ['binary', 'unary'], this.jumpWhite, 'op', this.jumpWhite, CheddarVariableToken
+            ]
+        );
+
+        if (res instanceof CheddarLexer) {
+            let modifier = res._Tokens[0];
+            let operator = res._Tokens[1]._Tokens[0];
+
+            if (modifier === 'unary') {
+                UOP.push(operator);
+            } else if (modifier === 'binary') {
+                OP.push(operator);
+            }
+
+        }
+
+        this._Tokens = [ res._Tokens[0], res._Tokens[1]._Tokens[0] ];
+
+        return res;
+    }
+

--- a/src/tokenizer/tok.es6
+++ b/src/tokenizer/tok.es6
@@ -13,7 +13,8 @@ import S1_ASSIGN from './states/assign';
 import S2_IF from './states/if';
 import S2_FOR from './states/for';
 import S3_FUNC from './states/func';
-import S4_EXPR from './states/expr';
+import S4_OP from './states/op';
+import EXPR from './states/expr';
 
 var CLOSES = '\n;';
 
@@ -36,7 +37,8 @@ export default class CheddarTokenize extends CheddarLexer {
             S2_IF,
             S2_FOR,
             S3_FUNC,
-            S4_EXPR
+            S4_OP,
+            EXPR
         ]), {
             tok: this.constructor,
             args: { ENDS, PARSERS }


### PR DESCRIPTION
Using `binary op` or `unary op` you can now create operators based
on a variable name. Expanding the available tokens for operators
will be done later.