### PR TITLE
User-defined operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "atob": "^2.0.3",
     "bases": "^0.2.1",
     "btoa": "^1.1.2",
-    "cheddar-parser": "^0.2.1",
+    "cheddar-parser": "^0.2.2",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
     "crypto": "0.0.3",

--- a/src/interpreter/links.es6
+++ b/src/interpreter/links.es6
@@ -5,11 +5,13 @@ import StatementBreak      from './states/break';
 import StatementClass      from './states/class';
 import StatementFunc       from './states/func';
 import StatementFor        from './states/for';
+import StatementOp         from './states/op';
 import StatementIf         from './states/if';
 
 export default delay_addition => ({
     StatementAssign,
     StatementIf,
+    StatementOp,
     StatementFor,
     StatementFunc,
     StatementClass,

--- a/src/interpreter/states/op.es6
+++ b/src/interpreter/states/op.es6
@@ -1,0 +1,4 @@
+export default class CheddarOp {
+    constructor() { }
+    exec() { }
+}


### PR DESCRIPTION
Added void-backend for user-defined operators which can be used
using the `unary op` and `binary op` commands.

Signed-off-by: Vihan B <contact@vihan.org>